### PR TITLE
chore: remove --headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OCR Tool**: `OCR(region, lang)` extracts text from screen regions. Uses pytesseract if available, falls back to Windows built-in OCR engine. `pytesseract` is an optional dependency (`pip install winremote-mcp[ocr]`).
 - **Screen Recording**: `ScreenRecord(duration, fps, region)` captures screen activity as animated GIF. Default 3s at 5fps, max 10s. Returns base64 GIF in ImageContent.
 - **Annotated Snapshot**: `AnnotatedSnapshot(max_elements)` takes a screenshot and overlays numbered red labels on interactive UI elements. Helps AI agents visually identify click targets.
-- **Headless Mode**: `--headless` CLI flag registers only platform-independent tools (Shell, File*, GetSystemInfo, ListProcesses, KillProcess, Scrape, Network, EventLog). Ideal for Docker, WSL, or Linux environments without a display.
 
 ## [0.2.0] - 2025-02-08
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Built with [FastMCP](https://github.com/jlowin/fastmcp). Runs **on the Windows m
 - **OCR** — extract text from screen regions (pytesseract or Windows built-in)
 - **Screen Recording** — capture animated GIF of screen activity
 - **Annotated Snapshot** — screenshot with numbered labels on interactive elements
-- **Headless Mode** — `--headless` flag for Docker/WSL (non-GUI tools only)
 - **Hot Reload** — `--reload` flag for development
 - **Auto-Start** — `winremote install` / `winremote uninstall` for Windows scheduled tasks
 
@@ -165,42 +164,6 @@ winremote-mcp uninstall
 | OCR | Extract text from screen via OCR (pytesseract or Windows built-in) |
 | ScreenRecord | Record screen activity as animated GIF |
 | AnnotatedSnapshot | Screenshot with numbered labels on interactive elements |
-
-### Headless mode (Docker / WSL / Linux)
-```bash
-winremote-mcp --headless
-```
-
-In headless mode, only platform-independent tools are registered — no GUI dependencies needed.
-
-## Docker / WSL / Linux Compatibility
-
-Most tools require a Windows desktop environment (pywin32, pyautogui), but several work on **any platform**:
-
-| Works Anywhere | Windows Only |
-|---|---|
-| Shell | Snapshot, Click, Type, Scroll, Move, Shortcut |
-| FileRead, FileWrite, FileList, FileSearch | FocusWindow, MinimizeAll, App |
-| FileDownload, FileUpload | GetClipboard, SetClipboard |
-| GetSystemInfo | Notification, LockScreen |
-| ListProcesses, KillProcess | OCR, ScreenRecord, AnnotatedSnapshot |
-| Scrape | RegRead, RegWrite |
-| Ping, PortCheck, NetConnections | ServiceList, ServiceStart, ServiceStop |
-| EventLog | TaskList, TaskCreate, TaskDelete |
-
-Use the `--headless` flag to start the server with only platform-independent tools. This is ideal for:
-
-- **Docker containers** — run file/shell/network tools without a display
-- **WSL** — manage Windows files and processes from Linux
-- **CI/CD** — integrate as an MCP server in headless pipelines
-
-```bash
-# Docker example
-docker run -p 8090:8090 winremote-mcp --headless --port 8090
-
-# WSL
-winremote-mcp --headless --transport stdio
-```
 
 ### OCR (optional dependency)
 

--- a/src/winremote/__main__.py
+++ b/src/winremote/__main__.py
@@ -1254,45 +1254,11 @@ def AnnotatedSnapshot(
 @click.option("--port", default=8090, type=int)
 @click.option("--reload", is_flag=True, default=False, help="Enable hot reload (streamable-http only)")
 @click.option("--auth-key", default=None, envvar="WINREMOTE_AUTH_KEY", help="API key for authentication")
-@click.option(
-    "--headless",
-    is_flag=True,
-    default=False,
-    help=(
-        "Register only non-GUI tools (Shell, File*, GetSystemInfo, "
-        "ListProcesses, KillProcess, Scrape, Network, EventLog). "
-        "Useful for Docker/WSL."
-    ),
-)
 @click.pass_context
-def cli(ctx, transport: str, host: str, port: int, reload: bool, auth_key: str | None, headless: bool):
+def cli(ctx, transport: str, host: str, port: int, reload: bool, auth_key: str | None):
     """Start the winremote MCP server."""
     if ctx.invoked_subcommand is not None:
         return  # subcommand will handle it
-
-    # In headless mode, remove GUI-dependent tools
-    if headless:
-        _headless_tool_names = {
-            "Shell",
-            "FileRead",
-            "FileWrite",
-            "FileList",
-            "FileSearch",
-            "FileDownload",
-            "FileUpload",
-            "GetSystemInfo",
-            "ListProcesses",
-            "KillProcess",
-            "Scrape",
-            "Ping",
-            "PortCheck",
-            "NetConnections",
-            "EventLog",
-        }
-        # Remove tools not in the headless set
-        to_remove = [name for name in mcp._tool_manager._tools if name not in _headless_tool_names]
-        for name in to_remove:
-            del mcp._tool_manager._tools[name]
 
     # Apply auth middleware if key is set
     if auth_key:


### PR DESCRIPTION
Remove the `--headless` CLI flag per user request. The three new tools (OCR, ScreenRecord, AnnotatedSnapshot) remain.

### Removed
- `--headless` CLI option and tool filtering logic from `__main__.py`
- Docker/WSL compatibility section from README
- Headless Mode entry from CHANGELOG