### PR TITLE
security: default bind 127.0.0.1 + security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ winremote-mcp
 uv run winremote-mcp
 ```
 
-### Streamable HTTP transport (default, for remote access)
+### Streamable HTTP transport (default)
 ```bash
-winremote-mcp --transport streamable-http --host 0.0.0.0 --port 8090
+# Local only (default: 127.0.0.1)
+winremote-mcp
+
+# Remote access — explicitly bind to all interfaces
+winremote-mcp --host 0.0.0.0 --port 8090
 ```
 
 ### With hot reload (development)
@@ -250,6 +254,31 @@ Ready-to-use skill packages for popular AI platforms:
 ```
 
 See [docs/openclaw-integration.md](docs/openclaw-integration.md) for detailed setup with authentication.
+
+## Security
+
+**Default bind: `127.0.0.1` (localhost only).** Remote access requires explicit `--host 0.0.0.0`.
+
+When exposing to the network:
+- **Always use `--auth-key`** — without it, anyone on the network has full access
+- **Use a firewall** — restrict port 8090 to trusted IPs only
+- **Consider a reverse proxy** — nginx/caddy with TLS for encrypted connections
+- **Network segmentation** — run on a private VLAN, not the public internet
+
+### Current security model
+
+| Feature | Status |
+|---------|--------|
+| Bearer token auth | ✅ `--auth-key` |
+| Localhost by default | ✅ `127.0.0.1` |
+| Health endpoint public | ✅ No auth needed |
+| Per-tool permissions | ❌ Not yet |
+| Operation audit log | ❌ Not yet |
+| IP allowlist | ❌ Not yet |
+| Rate limiting | ❌ Not yet |
+| Shell sandboxing | ❌ Not yet |
+
+> ⚠️ **This tool is designed for personal use in trusted networks** (e.g., local development, LAN). Do not expose to the public internet without additional security layers.
 
 ## Acknowledgments
 

--- a/skill/openclaw/SKILL.md
+++ b/skill/openclaw/SKILL.md
@@ -13,7 +13,10 @@ Control a Windows machine remotely via MCP protocol. 40 tools for desktop automa
 ```bash
 pip install winremote-mcp
 python -m winremote
-# Server starts on http://0.0.0.0:8090/mcp
+# Server starts on http://127.0.0.1:8090/mcp (local only)
+
+# For remote access:
+python -m winremote --host 0.0.0.0
 ```
 
 **With authentication (recommended):**

--- a/src/winremote/__main__.py
+++ b/src/winremote/__main__.py
@@ -1326,7 +1326,7 @@ _wrap_all_tools()
 
 @click.group(invoke_without_command=True)
 @click.option("--transport", default="streamable-http", type=click.Choice(["stdio", "streamable-http"]))
-@click.option("--host", default="0.0.0.0")
+@click.option("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1; use 0.0.0.0 for remote access)")
 @click.option("--port", default=8090, type=int)
 @click.option("--reload", is_flag=True, default=False, help="Enable hot reload (streamable-http only)")
 @click.option("--auth-key", default=None, envvar="WINREMOTE_AUTH_KEY", help="API key for authentication")
@@ -1362,18 +1362,22 @@ def cli(ctx, transport: str, host: str, port: int, reload: bool, auth_key: str |
             if not self._shown and "Application startup complete" in record.getMessage():
                 self._shown = True
                 auth_line = "[auth ON]" if auth_key else "[no auth]"
+                bind_line = f"[{host}:{port}]"
                 pad = " " * 10  # align with uvicorn log text
                 ver_line = f"winremote-mcp v{__version__}"
-                print(
-                    "\n"
-                    f"{pad}+----------------------------------+\n"
-                    f"{pad}|  {ver_line:<32s}|\n"
-                    f"{pad}|  by dddabtc                      |\n"
-                    f"{pad}|  github.com/dddabtc              |\n"
-                    f"{pad}|  {auth_line:<32s}|\n"
-                    f"{pad}+----------------------------------+\n",
-                    flush=True,
-                )
+                lines = [
+                    f"{pad}+----------------------------------+",
+                    f"{pad}|  {ver_line:<32s}|",
+                    f"{pad}|  by dddabtc                      |",
+                    f"{pad}|  github.com/dddabtc              |",
+                    f"{pad}|  {auth_line:<32s}|",
+                    f"{pad}|  {bind_line:<32s}|",
+                    f"{pad}+----------------------------------+",
+                ]
+                if host == "0.0.0.0" and not auth_key:
+                    lines.append(f"{pad}  WARNING: open to network without auth!")
+                    lines.append(f"{pad}  Use --auth-key for security.")
+                print("\n" + "\n".join(lines) + "\n", flush=True)
             return True
 
     if transport == "stdio":


### PR DESCRIPTION
Addresses security review feedback:
- Default bind changed to 127.0.0.1 (was 0.0.0.0)
- Security section added to README with honest feature matrix
- Banner warns when network-exposed without auth
- Skill docs updated