### PR TITLE
feat: native 4K screenshot support

### DIFF
--- a/src/winremote/__main__.py
+++ b/src/winremote/__main__.py
@@ -152,7 +152,7 @@ def _ensure_session_connected() -> str | None:
 def Snapshot(
     use_vision: bool | str = True,
     quality: int = 75,
-    max_width: int = 1920,
+    max_width: int = 0,
     monitor: int = 0,
 ) -> list:
     """Capture desktop screenshot, window list, and interactive UI elements.
@@ -160,7 +160,7 @@ def Snapshot(
     Args:
         use_vision: Include screenshot image (default True).
         quality: JPEG quality 1-100 (default 75). Lower = smaller.
-        max_width: Max image width in pixels (default 1920). Resized keeping aspect ratio.
+        max_width: Max image width in pixels. 0=native resolution (default). Set to e.g. 1920 to downscale.
         monitor: Monitor to capture. 0=all monitors (default), 1/2/3=specific monitor.
 
     Returns a list containing:
@@ -1331,7 +1331,7 @@ def ScreenRecord(
 def AnnotatedSnapshot(
     max_elements: int = 30,
     quality: int = 75,
-    max_width: int = 1920,
+    max_width: int = 0,
 ) -> list:
     """Take a screenshot with numbered labels on interactive UI elements.
 
@@ -1341,7 +1341,7 @@ def AnnotatedSnapshot(
     Args:
         max_elements: Maximum number of elements to annotate (default 30).
         quality: JPEG quality 1-100 (default 75).
-        max_width: Max image width in pixels (default 1920).
+        max_width: Max image width in pixels. 0=native resolution (default).
     """
     try:
         import io
@@ -1364,7 +1364,7 @@ def AnnotatedSnapshot(
                         text=f"AnnotatedSnapshot error (after session reconnect): {retry_error}",
                     )
                 ]
-        if img.width > max_width:
+        if max_width > 0 and img.width > max_width:
             ratio = max_width / img.width
             img = img.resize((max_width, int(img.height * ratio)))
 

--- a/src/winremote/desktop.py
+++ b/src/winremote/desktop.py
@@ -25,6 +25,15 @@ except ImportError:
 
 from PIL import ImageGrab
 
+# Enable DPI awareness so screenshots capture native resolution (e.g. 4K)
+try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
+except Exception:
+    try:
+        ctypes.windll.user32.SetProcessDPIAware()
+    except Exception:
+        pass
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -150,12 +159,12 @@ def _get_monitor_bbox(monitor: int) -> tuple[int, int, int, int] | None:
         raise
 
 
-def take_screenshot(quality: int = 75, max_width: int = 1920, monitor: int = 0) -> str:
+def take_screenshot(quality: int = 75, max_width: int = 0, monitor: int = 0) -> str:
     """Capture screen, return base64 JPEG. Resizes if wider than max_width.
 
     Args:
         quality: JPEG quality 1-100.
-        max_width: Max width in pixels.
+        max_width: Max width in pixels. 0=no resize (native resolution).
         monitor: 0=all monitors, 1/2/3=specific monitor.
     """
     if monitor == 0:
@@ -164,7 +173,7 @@ def take_screenshot(quality: int = 75, max_width: int = 1920, monitor: int = 0) 
         bbox = _get_monitor_bbox(monitor)
         img = ImageGrab.grab(bbox=bbox)
     # Resize if needed
-    if img.width > max_width:
+    if max_width > 0 and img.width > max_width:
         ratio = max_width / img.width
         new_height = int(img.height * ratio)
         img = img.resize((max_width, new_height), resample=3)  # LANCZOS


### PR DESCRIPTION
- DPI awareness enabled at module load
- Default max_width changed from 1920 to 0 (native resolution)
- Verified on 136: Snapshot outputs 3840x2160 on 4K display with 150% DPI scaling
- AnnotatedSnapshot also updated