### PR TITLE
fix: lint errors in tiers.py and __main__.py

### DIFF
--- a/src/winremote/__main__.py
+++ b/src/winremote/__main__.py
@@ -1514,7 +1514,10 @@ _wrap_all_tools()
 @click.option("--port", default=8090, type=int)
 @click.option("--reload", is_flag=True, default=False, help="Enable hot reload (streamable-http only)")
 @click.option("--auth-key", default=None, envvar="WINREMOTE_AUTH_KEY", help="API key for authentication")
-@click.option("--enable-all", is_flag=True, default=False, help="Enable all 43 tools including high-risk Tier 3 tools (Shell, FileWrite, KillProcess, etc.)")
+@click.option(
+    "--enable-all", is_flag=True, default=False,
+    help="Enable all 43 tools including high-risk Tier 3 tools (Shell, FileWrite, KillProcess, etc.)",
+)
 @click.option("--disable-tier2", is_flag=True, default=False, help="Disable interactive tools (Click, Type, etc.)")
 @click.option("--tools", default="", help="Comma-separated list of specific tools to enable (overrides tiers)")
 @click.option("--exclude-tools", default="", help="Comma-separated list of tools to disable")
@@ -1532,7 +1535,7 @@ def cli(ctx, transport: str, host: str, port: int, reload: bool, auth_key: str |
         tools=set(tools.split(",")) if tools.strip() else None,
         exclude_tools=set(exclude_tools.split(",")) if exclude_tools.strip() else None,
     )
-    
+
     tool_stats = filter_tools(mcp, enabled_tools_set)
     enabled_tiers = get_tier_names(enabled_tools_set)
 

--- a/src/winremote/tiers.py
+++ b/src/winremote/tiers.py
@@ -10,13 +10,13 @@ TOOL_TIERS = {
         "OCR", "ScreenRecord", "Notification", "Wait",
         "GetTaskStatus", "GetRunningTasks",
     },
-    
+
     # Tier 2: Interactive (medium risk, default enabled)
     "tier2": {
         "Click", "Type", "Move", "Scroll", "Shortcut",
         "FocusWindow", "MinimizeAll", "App", "Scrape", "CancelTask",
     },
-    
+
     # Tier 3: Destructive (high risk, default DISABLED)
     "tier3": {
         "Shell", "FileRead", "FileWrite", "FileDownload", "FileUpload",
@@ -35,13 +35,13 @@ def get_enabled_tools(
     exclude_tools=None,
 ):
     """Calculate the set of enabled tools based on options.
-    
+
     Args:
         enable_all: Enable all tiers (including high-risk tier3 tools)
         disable_tier2: Disable interactive tools (Click, Type, etc.)
         tools: Explicit tool list overrides tiers
         exclude_tools: Tools to exclude from the enabled set
-        
+
     Returns:
         Set of enabled tool names
     """
@@ -54,57 +54,57 @@ def get_enabled_tools(
             enabled |= TOOL_TIERS["tier2"]
         if enable_all:
             enabled |= TOOL_TIERS["tier3"]
-    
+
     if exclude_tools:
         enabled -= exclude_tools
-    
+
     return enabled
 
 
 def filter_tools(mcp, enabled_tools):
     """Remove tools not in the enabled set from the MCP server.
-    
+
     Args:
         mcp: FastMCP instance
         enabled_tools: Set of tool names to keep enabled
-        
+
     Returns:
         Dictionary with counts: {"enabled": int, "disabled": int, "total": int}
     """
     all_tools = list(mcp._tool_manager._tools.keys())
     total_count = len(all_tools)
-    
+
     # Remove disabled tools
     for name in all_tools:
         if name not in enabled_tools:
             del mcp._tool_manager._tools[name]
-    
+
     enabled_count = len(enabled_tools)
     disabled_count = total_count - enabled_count
-    
+
     return {
         "enabled": enabled_count,
-        "disabled": disabled_count, 
+        "disabled": disabled_count,
         "total": total_count
     }
 
 
 def get_tier_names(enabled_tools):
     """Get list of enabled tier names based on tools.
-    
+
     Args:
         enabled_tools: Set of enabled tool names
-        
+
     Returns:
         List of enabled tier names (e.g., ["1", "2"] or ["1", "2", "3"])
     """
     enabled_tiers = []
-    
+
     if TOOL_TIERS["tier1"] & enabled_tools:
         enabled_tiers.append("1")
     if TOOL_TIERS["tier2"] & enabled_tools:
-        enabled_tiers.append("2") 
+        enabled_tiers.append("2")
     if TOOL_TIERS["tier3"] & enabled_tools:
         enabled_tiers.append("3")
-        
+
     return enabled_tiers


### PR DESCRIPTION
Fix ruff lint errors: trailing whitespace, missing newlines, line too long.