### PR TITLE
Add config file, IP allowlist, and tier/tool resolution controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,66 @@ pip install winremote-mcp[ocr]
 ## Usage
 
 ### Basic Usage
+
+### Tier and tool controls
+```bash
+# Default: tier1 + tier2 enabled, tier3 disabled
+winremote-mcp
+
+# Enable destructive tier3 tools
+winremote-mcp --enable-tier3
+
+# Disable interactive tier2 (tier1 only)
+winremote-mcp --disable-tier2
+
+# Both together: tier1 + tier3 (tier2 disabled)
+winremote-mcp --enable-tier3 --disable-tier2
+
+# Backward-compatible: enable everything
+winremote-mcp --enable-all
+
+# Explicit tool list (highest precedence over tier flags)
+winremote-mcp --tools Snapshot,Click,Type
+
+# Remove specific tools from resolved set
+winremote-mcp --enable-tier3 --exclude-tools Shell,FileWrite
+```
+
+### Config file (`winremote.toml`)
+Search order:
+1. `--config /path/to/winremote.toml`
+2. `./winremote.toml`
+3. `~/.config/winremote/winremote.toml`
+
+```toml
+[server]
+host = "127.0.0.1"
+port = 8090
+auth_key = ""
+
+[security]
+ip_allowlist = ["127.0.0.1", "192.168.1.0/24"]
+enable_tier3 = false
+disable_tier2 = false
+
+[tools]
+enable = ["Snapshot", "Click", "Type"]
+exclude = []
+```
+
+**Precedence:** CLI flags override config file values; config file values override defaults.
+
+### IP allowlist
+```bash
+# CLI
+winremote-mcp --ip-allowlist 127.0.0.1,192.168.1.0/24
+
+# Or via config [security].ip_allowlist
+```
+
+Supports both single IPs and CIDR ranges (IPv4/IPv6). Non-allowlisted clients receive HTTP 403 with a clear error.
+
+### Health check
 ```bash
 # Start MCP server (localhost only, no auth)
 winremote-mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "thefuzz[speedup]>=0.20.0",
     "tabulate>=0.9.0",
     "markdownify>=0.13.0",
+    "tomli>=2.0.1; python_version < '3.11'",
 ]
 
 [project.scripts]
@@ -35,7 +36,7 @@ winremote-mcp = "winremote.__main__:cli"
 
 [project.optional-dependencies]
 ocr = ["pytesseract>=0.3.10"]
-dev = ["ruff>=0.9.0"]
+dev = ["ruff>=0.9.0", "pytest>=8.0.0"]
 test = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",

--- a/src/winremote/config.py
+++ b/src/winremote/config.py
@@ -1,0 +1,101 @@
+"""Configuration loading and merge utilities for winremote-mcp."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
+
+
+@dataclass
+class ServerConfig:
+    host: str = "127.0.0.1"
+    port: int = 8090
+    auth_key: str | None = None
+
+
+@dataclass
+class SecurityConfig:
+    ip_allowlist: list[str] = field(default_factory=list)
+    enable_tier3: bool = False
+    disable_tier2: bool = False
+
+
+@dataclass
+class ToolsConfig:
+    enable: list[str] = field(default_factory=list)
+    exclude: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WinRemoteConfig:
+    server: ServerConfig = field(default_factory=ServerConfig)
+    security: SecurityConfig = field(default_factory=SecurityConfig)
+    tools: ToolsConfig = field(default_factory=ToolsConfig)
+    source_path: Path | None = None
+
+
+def discover_config_path(explicit_path: str | None) -> Path | None:
+    """Find config path using precedence: explicit > cwd > ~/.config."""
+    if explicit_path:
+        path = Path(explicit_path).expanduser()
+        return path
+
+    cwd_path = Path.cwd() / "winremote.toml"
+    if cwd_path.exists():
+        return cwd_path
+
+    user_path = Path("~/.config/winremote/winremote.toml").expanduser()
+    if user_path.exists():
+        return user_path
+    return None
+
+
+def _list_of_strings(raw: object, key: str) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(isinstance(i, str) for i in raw):
+        raise ValueError(f"{key} must be an array of strings")
+    return raw
+
+
+def load_config(path: Path | None) -> WinRemoteConfig:
+    """Load and validate TOML config file. Returns defaults when path is None."""
+    cfg = WinRemoteConfig()
+    if path is None:
+        return cfg
+
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+
+    server = data.get("server", {})
+    security = data.get("security", {})
+    tools = data.get("tools", {})
+
+    if "host" in server:
+        cfg.server.host = str(server["host"])
+    if "port" in server:
+        cfg.server.port = int(server["port"])
+    if "auth_key" in server:
+        cfg.server.auth_key = str(server["auth_key"])
+
+    if "ip_allowlist" in security:
+        cfg.security.ip_allowlist = _list_of_strings(security["ip_allowlist"], "security.ip_allowlist")
+    if "enable_tier3" in security:
+        cfg.security.enable_tier3 = bool(security["enable_tier3"])
+    if "disable_tier2" in security:
+        cfg.security.disable_tier2 = bool(security["disable_tier2"])
+
+    if "enable" in tools:
+        cfg.tools.enable = _list_of_strings(tools["enable"], "tools.enable")
+    if "exclude" in tools:
+        cfg.tools.exclude = _list_of_strings(tools["exclude"], "tools.exclude")
+
+    cfg.source_path = path
+    return cfg

--- a/src/winremote/security.py
+++ b/src/winremote/security.py
@@ -1,0 +1,64 @@
+"""Security helpers: IP allowlist parsing + middleware."""
+
+from __future__ import annotations
+
+import ipaddress
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+
+def parse_ip_allowlist(raw_entries: list[str]) -> list[ipaddress._BaseNetwork]:
+    """Parse allowlist entries of single IPs and CIDR ranges."""
+    parsed: list[ipaddress._BaseNetwork] = []
+    errors: list[str] = []
+
+    for entry in raw_entries:
+        value = entry.strip()
+        if not value:
+            continue
+        try:
+            if "/" in value:
+                parsed.append(ipaddress.ip_network(value, strict=False))
+            else:
+                ip_obj = ipaddress.ip_address(value)
+                suffix = "/32" if ip_obj.version == 4 else "/128"
+                parsed.append(ipaddress.ip_network(f"{ip_obj}{suffix}", strict=False))
+        except ValueError as exc:
+            errors.append(f"{entry}: {exc}")
+
+    if errors:
+        raise ValueError("Invalid IP allowlist entries: " + "; ".join(errors))
+
+    return parsed
+
+
+class IPAllowlistMiddleware(BaseHTTPMiddleware):
+    """Restrict access to configured client IP networks."""
+
+    def __init__(self, app, allowlist: list[ipaddress._BaseNetwork]):
+        super().__init__(app)
+        self.allowlist = allowlist
+
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health":
+            return await call_next(request)
+
+        client = request.client
+        if client is None:
+            return JSONResponse({"error": "Forbidden: missing client address"}, status_code=403)
+
+        try:
+            client_ip = ipaddress.ip_address(client.host)
+        except ValueError:
+            return JSONResponse({"error": f"Forbidden: invalid client address {client.host}"}, status_code=403)
+
+        if not any(client_ip in net for net in self.allowlist):
+            return JSONResponse(
+                {
+                    "error": f"Forbidden: client IP {client_ip} is not in allowlist",
+                },
+                status_code=403,
+            )
+
+        return await call_next(request)

--- a/tests/test_config_and_tiers.py
+++ b/tests/test_config_and_tiers.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import pytest
+
+from winremote.config import discover_config_path, load_config
+from winremote.security import parse_ip_allowlist
+from winremote.tiers import resolve_enabled_tools
+
+
+def test_config_loader_reads_toml(tmp_path: Path):
+    cfg_file = tmp_path / "winremote.toml"
+    cfg_file.write_text(
+        """
+[server]
+host = "0.0.0.0"
+port = 9000
+auth_key = "abc"
+
+[security]
+ip_allowlist = ["127.0.0.1", "10.0.0.0/8"]
+enable_tier3 = true
+disable_tier2 = false
+
+[tools]
+enable = ["Snapshot", "Click", "Type"]
+exclude = ["Type"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(cfg_file)
+    assert cfg.server.host == "0.0.0.0"
+    assert cfg.server.port == 9000
+    assert cfg.server.auth_key == "abc"
+    assert cfg.security.ip_allowlist == ["127.0.0.1", "10.0.0.0/8"]
+    assert cfg.security.enable_tier3 is True
+    assert cfg.tools.enable == ["Snapshot", "Click", "Type"]
+    assert cfg.tools.exclude == ["Type"]
+
+
+def test_discover_config_path_prefers_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = tmp_path / "winremote.toml"
+    cfg.write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    found = discover_config_path(None)
+    assert found == cfg
+
+
+def test_tier_resolution_defaults():
+    enabled = resolve_enabled_tools()
+    assert "Snapshot" in enabled
+    assert "Click" in enabled
+    assert "Shell" not in enabled
+
+
+def test_tier_resolution_flags():
+    disabled_t2 = resolve_enabled_tools(disable_tier2=True)
+    assert "Click" not in disabled_t2
+    assert "Snapshot" in disabled_t2
+
+    with_t3 = resolve_enabled_tools(enable_tier3=True)
+    assert "Shell" in with_t3
+
+    both = resolve_enabled_tools(enable_tier3=True, disable_tier2=True)
+    assert "Click" not in both
+    assert "Shell" in both
+
+
+def test_explicit_tools_override_tiers():
+    enabled = resolve_enabled_tools(
+        enable_tier3=False,
+        disable_tier2=True,
+        explicit_tools=["snapshot", "click", "type"],
+    )
+    assert enabled == {"Snapshot", "Click", "Type"}
+
+
+def test_invalid_tool_rejected():
+    with pytest.raises(ValueError):
+        resolve_enabled_tools(explicit_tools=["NopeTool"])
+
+
+def test_ip_allowlist_parsing():
+    nets = parse_ip_allowlist(["127.0.0.1", "192.168.1.0/24", "::1"])
+    assert len(nets) == 3
+
+
+def test_ip_allowlist_invalid():
+    with pytest.raises(ValueError):
+        parse_ip_allowlist(["not-an-ip"])


### PR DESCRIPTION
## Summary\n- add  support with search order: , , \n- add robust IP allowlist parsing (single IP + CIDR, IPv4/IPv6) and HTTP middleware enforcement\n- add  and keep backward-compatible \n- keep  highest precedence and support \n- apply precedence: CLI > config > defaults\n- add tests for config parsing, tier/tool resolution, and allowlist parsing\n- update README with examples and precedence docs\n\n## Validation\n- All checks passed!\n- 26 files already formatted\n- \n