### PR TITLE
Fix FastMCP middleware compatibility for auth/ip allowlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winremote-mcp"
-version = "0.4.6"
+version = "0.4.7"
 description = "Windows Remote MCP Server - control Windows desktops via MCP protocol"
 readme = "README.md"
 license = "MIT"

--- a/src/winremote/__init__.py
+++ b/src/winremote/__init__.py
@@ -1,3 +1,3 @@
 """winremote-mcp: Windows Remote MCP Server."""
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ class TestHealthEndpoint:
         try:
             from starlette.testclient import TestClient
 
-            app = mcp._get_app()
+            app = mcp.http_app(transport="streamable-http")
             client = TestClient(app)
             resp = client.get("/health")
             assert resp.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,63 @@
+"""Unit tests for IP allowlist middleware and parsing."""
+
+from __future__ import annotations
+
+import ipaddress
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from winremote.security import IPAllowlistMiddleware, parse_ip_allowlist
+
+
+def _make_app(allowlist: list[str]):
+    async def homepage(request):
+        return JSONResponse({"ok": True})
+
+    async def health(request):
+        return JSONResponse({"status": "ok"})
+
+    app = Starlette(
+        routes=[
+            Route("/", homepage),
+            Route("/health", health),
+        ]
+    )
+    app.add_middleware(IPAllowlistMiddleware, allowlist=parse_ip_allowlist(allowlist))
+    return app
+
+
+class TestParseIPAllowlist:
+    def test_parses_ip_and_cidr(self):
+        parsed = parse_ip_allowlist(["127.0.0.1", "10.0.0.0/24"])
+        assert ipaddress.ip_address("127.0.0.1") in parsed[0]
+        assert ipaddress.ip_address("10.0.0.42") in parsed[1]
+
+    def test_invalid_entries_raise(self):
+        try:
+            parse_ip_allowlist(["bad-ip"])
+            assert False, "Expected ValueError"
+        except ValueError as exc:
+            assert "bad-ip" in str(exc)
+
+
+class TestIPAllowlistMiddleware:
+    def test_health_is_public(self):
+        app = _make_app(["127.0.0.1/32"])
+        client = TestClient(app, client=("10.1.2.3", 1234))
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_allowed_ip_passes(self):
+        app = _make_app(["127.0.0.1/32"])
+        client = TestClient(app, client=("127.0.0.1", 1234))
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    def test_blocked_ip_returns_403(self):
+        app = _make_app(["127.0.0.1/32"])
+        client = TestClient(app, client=("10.1.2.3", 1234))
+        resp = client.get("/")
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary\n- replace private  monkeypatching with public FastMCP HTTP  injection\n- keep  +  behavior for streamable-http\n- switch integration test to  public API\n- add IP allowlist middleware unit tests (IP + CIDR, 403 behavior, /health bypass)\n- bump version to 0.4.7\n\n## Verification\n- All checks passed!\n- 27 files already formatted\n- \n- smoke: started streamable-http with ; verified  200, localhost  unauthenticated 401, non-allowlisted client IP 403