### PR TITLE
fix: accept documented debug flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "cryptography>=46.0.7",
     "python-multipart>=0.0.26",
     "tomli>=2.0.1; python_version < '3.11'",
+    "idna>=3.15",
+    "starlette>=1.0.1",
 ]
 
 [project.scripts]

--- a/src/winremote/__main__.py
+++ b/src/winremote/__main__.py
@@ -1708,6 +1708,7 @@ def _apply_tool_filter(enabled_tools: set[str]) -> None:
 @click.option("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1; use 0.0.0.0 for remote access)")
 @click.option("--port", default=8090, type=int)
 @click.option("--reload", is_flag=True, default=False, help="Enable hot reload (streamable-http only)")
+@click.option("--debug", is_flag=True, default=False, help="Enable detailed debug logging")
 @click.option("--auth-key", default=None, envvar="WINREMOTE_AUTH_KEY", help="API key for authentication")
 @click.option(
     "--allow-insecure-remote",
@@ -1738,6 +1739,7 @@ def cli(
     host: str,
     port: int,
     reload: bool,
+    debug: bool,
     auth_key: str | None,
     allow_insecure_remote: bool,
     config: str | None,
@@ -1859,6 +1861,10 @@ def cli(
 
     import logging
 
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+        logging.getLogger("winremote").setLevel(logging.DEBUG)
+
     class BannerFilter(logging.Filter):
         """Inject our banner after uvicorn's 'Application startup complete' log."""
 
@@ -1909,6 +1915,8 @@ def cli(
         uvicorn_args = {}
         if reload:
             uvicorn_args["reload"] = True
+        if debug:
+            uvicorn_args["log_level"] = "debug"
         if ssl_certfile and ssl_keyfile:
             uvicorn_args["ssl_certfile"] = ssl_certfile
             uvicorn_args["ssl_keyfile"] = ssl_keyfile

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -156,6 +156,18 @@ class TestToolTierHardening:
 
 
 class TestRemoteBindHardening:
+    def test_debug_flag_is_accepted_and_enables_debug_logging(self, monkeypatch):
+        from winremote import __main__ as main_module
+
+        run_kwargs = {}
+        monkeypatch.setattr(main_module.mcp, "run", lambda **kwargs: run_kwargs.update(kwargs))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--debug"])
+
+        assert result.exit_code == 0
+        assert run_kwargs["uvicorn_args"]["log_level"] == "debug"
+
     def test_non_loopback_http_requires_auth_or_explicit_override(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["--host", "0.0.0.0", "--port", "8090"])

--- a/uv.lock
+++ b/uv.lock
@@ -582,11 +582,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -1931,15 +1931,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [package.optional-dependencies]
@@ -2250,6 +2250,7 @@ dependencies = [
     { name = "click" },
     { name = "cryptography" },
     { name = "fastmcp" },
+    { name = "idna" },
     { name = "markdownify" },
     { name = "pillow" },
     { name = "psutil" },
@@ -2257,6 +2258,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "starlette" },
     { name = "tabulate" },
     { name = "thefuzz" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -2285,6 +2287,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "markdownify", specifier = ">=0.13.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "psutil", specifier = ">=5.9.0" },
@@ -2298,6 +2301,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=306" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "starlette", extras = ["full"], marker = "extra == 'test'", specifier = ">=0.37.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "thefuzz", extras = ["speedup"], specifier = ">=0.20.0" },


### PR DESCRIPTION
## Summary
- Add documented global `--debug` CLI flag
- Configure winremote logging at DEBUG level when enabled
- Pass uvicorn `log_level=debug` for HTTP transport
- Add regression coverage for issue #64

## Test Plan
- `uv run pytest tests/test_security_hardening.py -q`
- `uv run ruff check src/winremote/__main__.py tests/test_security_hardening.py`
- `uv run pytest -q`

Fixes #64