### PR TITLE
chore: prepare v0.4.22 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.22] - 2026-05-22
+
+### Fixed
+
+- Add the documented `--debug` CLI flag and enable debug logging for winremote/uvicorn when it is set.
+
+### Security
+
+- Add minimum dependency constraints for `idna>=3.15` and `starlette>=1.0.1` to avoid known vulnerable versions.
+
+### Docs
+
+- Keep only the latest two `What's New` sections in README and point older release notes to the full changelog.
+
 ## [0.4.21] - 2026-05-05
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -233,36 +233,27 @@ exclude = ["ScreenRecord"]   # disable specific tools
 
 > **Note:** winremote-mcp is a standard MCP server and works with any MCP-compatible client — Claude Desktop, Cursor, OpenClaw, and others.
 
+## What's New in v0.4.22
+
+### 🐛 Debug flag restored
+
+- Added the documented `--debug` CLI flag so `winremote-mcp --debug` is accepted.
+- `--debug` enables DEBUG logging for winremote and passes `log_level=debug` to uvicorn for HTTP transport.
+
+### 🔒 Dependency security updates
+
+- Added minimum constraints for `idna>=3.15` and `starlette>=1.0.1` to avoid known vulnerable versions.
+
+### 📚 README release notes cleanup
+
+- README now keeps only the latest two `What's New` sections.
+- Older release notes remain available in the full [CHANGELOG](CHANGELOG.md).
+
 ## What's New in v0.4.21
 
 ### 📚 README release notes cleanup
 
-- README now keeps only the latest three `What's New` sections.
-- Older release notes now point to the full [CHANGELOG](CHANGELOG.md) to keep the README focused.
-
-## What's New in v0.4.20
-
-### 🔒 Security hardening
-
-- Remote HTTP access now requires authentication by default. Non-loopback binds are refused unless you configure `--auth-key` or OAuth confidential-client auth.
-- `--allow-insecure-remote` is still available, but only as an explicit legacy / lab-only break-glass option.
-- OAuth dynamic client registration is disabled. OAuth now requires a pre-provisioned confidential client with client ID and client secret.
-- OAuth now requires PKCE `S256` and loopback redirect URIs.
-- `Scrape` and `PlaySound` URL fetching now blocks private, loopback, link-local, multicast, reserved, and unspecified targets to reduce SSRF risk.
-- `App` and `PlaySound` moved to Tier 3 because they can start programs or trigger server-side effects.
-
-### 🛡️ CI and supply-chain checks
-
-- Added CI security scans with Bandit, pip-audit, and zizmor.
-- Raised minimum dependency versions for FastMCP, Pillow, Authlib, cryptography, python-multipart, pytest, and Pygments.
-- Tightened GitHub Actions permissions and pinned workflow actions to immutable SHAs.
-
-## What's New in v0.4.19
-
-### 🤖 Hermes Integration
-
-- Added a Hermes setup guide for connecting winremote-mcp as a native MCP server.
-- Added README links to client-specific integration guides in this repository.
+- README keeps recent `What's New` sections focused and points older release notes to the full [CHANGELOG](CHANGELOG.md).
 
 For older release notes, see the full [CHANGELOG](CHANGELOG.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winremote-mcp"
-version = "0.4.21"
+version = "0.4.22"
 description = "Windows Remote MCP Server - control Windows desktops via MCP protocol"
 readme = "README.md"
 license = "MIT"

--- a/src/winremote/__init__.py
+++ b/src/winremote/__init__.py
@@ -1,3 +1,3 @@
 """winremote-mcp: Windows Remote MCP Server."""
 
-__version__ = "0.4.21"
+__version__ = "0.4.22"

--- a/uv.lock
+++ b/uv.lock
@@ -2243,7 +2243,7 @@ wheels = [
 
 [[package]]
 name = "winremote-mcp"
-version = "0.4.21"
+version = "0.4.22"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary
- Bump package version to 0.4.22
- Update README What's New to keep only the latest two versions
- Add v0.4.22 changelog notes

## Test Plan
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run --with build python -m build`