### PR TITLE
Prepare v0.4.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.23] - 2026-06-19
+
+### Fixed
+
+- Restore `winremote-mcp --debug` compatibility with FastMCP 3.2.4+ by detecting whether the installed FastMCP `run_http_async` expects `uvicorn_config` or the legacy `uvicorn_args` keyword.
+- Keep DEBUG uvicorn logging working across both new and older FastMCP releases.
+
+### Docs
+
+- Document the FastMCP debug/uvicorn compatibility fix in both English and Chinese README release notes.
+
 ## [0.4.22] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ exclude = ["ScreenRecord"]   # disable specific tools
 
 > **Note:** winremote-mcp is a standard MCP server and works with any MCP-compatible client — Claude Desktop, Cursor, OpenClaw, and others.
 
+## What's New in v0.4.23
+
+### 🐛 FastMCP debug/uvicorn compatibility
+
+- Fixed `winremote-mcp --debug` with FastMCP 3.2.4+, where `run_http_async` renamed the uvicorn options keyword from `uvicorn_args` to `uvicorn_config`.
+- winremote-mcp now detects the installed FastMCP signature and passes DEBUG uvicorn logging through the supported keyword, while preserving compatibility with older FastMCP releases.
+- Added regression coverage so the debug HTTP startup path stays compatible with both keyword names.
+
+### 中文发布说明
+
+- 修复 FastMCP 3.2.4+ 中 `run_http_async` 参数从 `uvicorn_args` 改为 `uvicorn_config` 后，`winremote-mcp --debug` 启动时报错的问题。
+- 现在会自动检测当前 FastMCP 支持的参数名，并继续把 uvicorn 的 DEBUG 日志配置传递给 HTTP 传输层；旧版 FastMCP 仍保持兼容。
+- 已添加回归测试，覆盖新旧 uvicorn 配置参数的兼容路径。
+
 ## What's New in v0.4.22
 
 ### 🐛 Debug flag restored

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winremote-mcp"
-version = "0.4.22"
+version = "0.4.23"
 description = "Windows Remote MCP Server - control Windows desktops via MCP protocol"
 readme = "README.md"
 license = "MIT"

--- a/src/winremote/__init__.py
+++ b/src/winremote/__init__.py
@@ -1,3 +1,3 @@
 """winremote-mcp: Windows Remote MCP Server."""
 
-__version__ = "0.4.22"
+__version__ = "0.4.23"

--- a/uv.lock
+++ b/uv.lock
@@ -2278,7 +2278,7 @@ wheels = [
 
 [[package]]
 name = "winremote-mcp"
-version = "0.4.22"
+version = "0.4.23"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary
- bump package version to 0.4.23 in pyproject, package metadata, and uv.lock
- add README release notes in English and Chinese for the FastMCP debug/uvicorn compatibility fix
- add changelog entry for v0.4.23

## Tests
- uv lock
- git diff --check
- uv run ruff check
- uv run ruff format --check
- uv run pytest (137 passed)